### PR TITLE
feat(mcp): MCP elicitation support (Phase A: confirm/choice)

### DIFF
--- a/api/server/routes/mcp.js
+++ b/api/server/routes/mcp.js
@@ -640,6 +640,44 @@ router.post('/oauth/cancel/:serverName', requireJwtAuth, async (req, res) => {
 });
 
 /**
+ * Records a user's response to an MCP elicitation prompt, completing the pending flow so the
+ * blocked tool call resumes. Flow ids are prefixed with the user id; we enforce that here so a
+ * user can only answer their own prompts.
+ */
+router.post('/elicitation/:flowId/respond', requireJwtAuth, async (req, res) => {
+  try {
+    const { flowId } = req.params;
+    const { action, content } = req.body ?? {};
+    const user = req.user;
+
+    if (!user?.id) {
+      return res.status(401).json({ error: 'User not authenticated' });
+    }
+    if (!['accept', 'decline', 'cancel'].includes(action)) {
+      return res.status(400).json({ error: 'Invalid action; expected accept | decline | cancel' });
+    }
+    if (!flowId.startsWith(`${user.id}:`)) {
+      return res.status(403).json({ error: 'Not authorized for this elicitation' });
+    }
+
+    const flowsCache = getLogStores(CacheKeys.FLOWS);
+    const flowManager = getFlowStateManager(flowsCache);
+    const completed = await flowManager.completeFlow(flowId, 'mcp_elicitation', {
+      action,
+      ...(content != null ? { content } : {}),
+    });
+
+    if (!completed) {
+      return res.status(404).json({ error: 'Elicitation flow not found or already completed' });
+    }
+    res.json({ success: true });
+  } catch (error) {
+    logger.error('[MCP Elicitation] Failed to record elicitation response', error);
+    res.status(500).json({ error: 'Failed to record elicitation response' });
+  }
+});
+
+/**
  * Reinitialize MCP server
  * This endpoint allows reinitializing a specific MCP server
  */

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -17,6 +17,8 @@ const {
   buildMCPAuthRunStepEvent,
   buildMCPAuthRunStepDeltaEvent,
   buildMCPAuthRunStepEndDeltaEvent,
+  buildMCPElicitationRunStepDeltaEvent,
+  buildMCPElicitationEndDeltaEvent,
   isUserSourced,
   checkAccessWithRequestCache,
   requiresEphemeralUserConnection,
@@ -808,6 +810,39 @@ function createToolInstance({
         streamId,
       });
 
+      // Elicitation: surface a server-requested confirm/choice prompt on this tool call and
+      // block (via a flow) until the user responds through the elicitation respond endpoint.
+      const elicitationFlowId = `${userId}:${serverName}:elicitation:${config.metadata.thread_id}:${config.metadata.run_id}:${stepId}`;
+      const emitElicitationEvent = async (eventData) => {
+        if (streamId) {
+          await GenerationJobManager.emitChunk(streamId, eventData);
+        } else {
+          sendEvent(res, eventData);
+        }
+      };
+      const elicitation = {
+        flowId: elicitationFlowId,
+        emit: async ({ flowId, message, choices, expiresAt }) => {
+          await emitElicitationEvent(
+            buildMCPElicitationRunStepDeltaEvent({
+              stepId,
+              toolCall,
+              flowId,
+              message,
+              choices,
+              expiresAt,
+            }),
+          );
+        },
+        resolve: async (flowId, signal) => {
+          try {
+            return await flowManager.createFlow(flowId, 'mcp_elicitation', {}, signal);
+          } finally {
+            await emitElicitationEvent(buildMCPElicitationEndDeltaEvent({ stepId, toolCall }));
+          }
+        },
+      };
+
       if (derivedSignal) {
         const tenantId = config?.configurable?.user?.tenantId ?? getTenantId();
         abortHandler = createAbortHandler({ userId, serverName, toolName, tenantId, flowManager });
@@ -840,6 +875,7 @@ function createToolInstance({
         },
         oauthStart,
         oauthEnd,
+        elicitation,
         graphTokenResolver: getGraphApiToken,
         oboTokenResolver: exchangeOboToken,
         oboTrustChecker: createOboTrustChecker(),

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -22,6 +22,7 @@ import {
   BashCall,
   SubagentCall,
 } from './Parts';
+import { isBashProgrammaticToolCall } from './routing';
 import { ErrorMessage } from './MessageContent';
 import RetrievalCall from './RetrievalCall';
 import { getCachedPreview } from '~/utils';
@@ -31,7 +32,6 @@ import Container from './Container';
 import WebSearch from './WebSearch';
 import ToolCall from './ToolCall';
 import Image from './Image';
-import { isBashProgrammaticToolCall } from './routing';
 
 type PartProps = {
   part?: TMessageContentParts;

--- a/client/src/components/Chat/Messages/Content/Part.tsx
+++ b/client/src/components/Chat/Messages/Content/Part.tsx
@@ -289,6 +289,7 @@ const Part = memo(function Part({
           isSubmitting={isSubmitting}
           attachments={attachments}
           auth={toolCall.auth}
+          elicitation={toolCall.elicitation}
           isLast={isLast}
           hideAttachments={hideAttachments}
           onExpand={onToolExpand}

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -292,41 +292,38 @@ export default function ToolCall({
           </p>
         </div>
       )}
-      {elicitation?.flowId != null &&
-        progress < 1 &&
-        !showCancelled &&
-        !elicitationResponded && (
-          <div className="my-2 flex w-full flex-col gap-2.5">
-            {elicitation.message && (
-              <p className="text-sm text-text-primary">{elicitation.message}</p>
-            )}
-            {elicitation.choices && elicitation.choices.length > 0 ? (
-              <div className="flex flex-wrap gap-2">
-                {elicitation.choices.map((choice) => (
-                  <Button
-                    key={choice.value}
-                    variant="default"
-                    onClick={() => respondElicitation('accept', { value: choice.value })}
-                  >
-                    {choice.label}
-                  </Button>
-                ))}
-                <Button variant="outline" onClick={() => respondElicitation('decline')}>
-                  {localize('com_ui_elicitation_decline')}
+      {elicitation?.flowId != null && progress < 1 && !showCancelled && !elicitationResponded && (
+        <div className="my-2 flex w-full flex-col gap-2.5">
+          {elicitation.message && (
+            <p className="text-sm text-text-primary">{elicitation.message}</p>
+          )}
+          {elicitation.choices && elicitation.choices.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {elicitation.choices.map((choice) => (
+                <Button
+                  key={choice.value}
+                  variant="default"
+                  onClick={() => respondElicitation('accept', { value: choice.value })}
+                >
+                  {choice.label}
                 </Button>
-              </div>
-            ) : (
-              <div className="flex gap-2">
-                <Button variant="default" onClick={() => respondElicitation('accept')}>
-                  {localize('com_ui_elicitation_confirm')}
-                </Button>
-                <Button variant="outline" onClick={() => respondElicitation('decline')}>
-                  {localize('com_ui_elicitation_decline')}
-                </Button>
-              </div>
-            )}
-          </div>
-        )}
+              ))}
+              <Button variant="outline" onClick={() => respondElicitation('decline')}>
+                {localize('com_ui_elicitation_decline')}
+              </Button>
+            </div>
+          ) : (
+            <div className="flex gap-2">
+              <Button variant="default" onClick={() => respondElicitation('accept')}>
+                {localize('com_ui_elicitation_confirm')}
+              </Button>
+              <Button variant="outline" onClick={() => respondElicitation('decline')}>
+                {localize('com_ui_elicitation_decline')}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
       {!hideAttachments && attachments && attachments.length > 0 && (
         <AttachmentGroup attachments={attachments} />
       )}

--- a/client/src/components/Chat/Messages/Content/ToolCall.tsx
+++ b/client/src/components/Chat/Messages/Content/ToolCall.tsx
@@ -27,6 +27,7 @@ export default function ToolCall({
   output,
   attachments,
   auth,
+  elicitation,
   hideAttachments = false,
   onExpand,
 }: {
@@ -38,6 +39,12 @@ export default function ToolCall({
   output?: string | null;
   attachments?: TAttachment[];
   auth?: string;
+  elicitation?: {
+    flowId: string;
+    message: string;
+    choices?: Array<{ value: string; label: string }>;
+    expires_at?: number;
+  };
   hideAttachments?: boolean;
   onExpand?: () => void;
 }) {
@@ -133,6 +140,23 @@ export default function ToolCall({
     }
     window.open(auth, '_blank', 'noopener,noreferrer');
   }, [auth, isMCPToolCall, mcpServerName, actionId]);
+
+  const [elicitationResponded, setElicitationResponded] = useState(false);
+  const respondElicitation = useCallback(
+    async (action: 'accept' | 'decline' | 'cancel', content?: Record<string, unknown>) => {
+      if (!elicitation?.flowId) {
+        return;
+      }
+      setElicitationResponded(true);
+      try {
+        await dataService.respondMCPElicitation(elicitation.flowId, { action, content });
+      } catch (e) {
+        logger.error('Failed to respond to MCP elicitation', e);
+        setElicitationResponded(false);
+      }
+    },
+    [elicitation?.flowId],
+  );
 
   const hasError = typeof output === 'string' && isError(output);
   const cancelled = !isSubmitting && initialProgress < 1 && !hasError;
@@ -268,6 +292,41 @@ export default function ToolCall({
           </p>
         </div>
       )}
+      {elicitation?.flowId != null &&
+        progress < 1 &&
+        !showCancelled &&
+        !elicitationResponded && (
+          <div className="my-2 flex w-full flex-col gap-2.5">
+            {elicitation.message && (
+              <p className="text-sm text-text-primary">{elicitation.message}</p>
+            )}
+            {elicitation.choices && elicitation.choices.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {elicitation.choices.map((choice) => (
+                  <Button
+                    key={choice.value}
+                    variant="default"
+                    onClick={() => respondElicitation('accept', { value: choice.value })}
+                  >
+                    {choice.label}
+                  </Button>
+                ))}
+                <Button variant="outline" onClick={() => respondElicitation('decline')}>
+                  {localize('com_ui_elicitation_decline')}
+                </Button>
+              </div>
+            ) : (
+              <div className="flex gap-2">
+                <Button variant="default" onClick={() => respondElicitation('accept')}>
+                  {localize('com_ui_elicitation_confirm')}
+                </Button>
+                <Button variant="outline" onClick={() => respondElicitation('decline')}>
+                  {localize('com_ui_elicitation_decline')}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
       {!hideAttachments && attachments && attachments.length > 0 && (
         <AttachmentGroup attachments={attachments} />
       )}

--- a/client/src/hooks/SSE/useStepHandler.ts
+++ b/client/src/hooks/SSE/useStepHandler.ts
@@ -863,6 +863,9 @@ export default function useStepHandler({
               contentPart.tool_call.expires_at = runStepDelta.delta.expires_at;
             }
 
+            // Pending elicitation prompt for this tool call; cleared when the delta omits it.
+            contentPart.tool_call.elicitation = runStepDelta.delta.elicitation;
+
             // Use server's index, offset by initialContent for edit scenarios
             const currentIndex = runStep.index + initialContent.length;
             updatedResponse = updateContent(

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -1001,6 +1001,8 @@
   "com_ui_duplication_processing": "Duplicating conversation...",
   "com_ui_duplication_success": "Successfully duplicated conversation",
   "com_ui_edit": "Edit",
+  "com_ui_elicitation_confirm": "Confirm",
+  "com_ui_elicitation_decline": "Decline",
   "com_ui_edit_editing_image": "Editing image",
   "com_ui_edit_mcp_server": "Edit MCP Server",
   "com_ui_edit_mcp_server_dialog_description": "Unique Server Identifier: {{serverName}}",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -14,6 +14,7 @@ export * from './mcp/registry/MCPServersRegistry';
 export * from './mcp/MCPManager';
 export * from './mcp/connection';
 export * from './mcp/oauth';
+export * from './mcp/elicitation/events';
 export * from './mcp/auth';
 export * from './mcp/zod';
 export * from './mcp/errors';

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -5,6 +5,7 @@ import { CallToolResultSchema, ErrorCode, McpError } from '@modelcontextprotocol
 import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import type { TokenMethods, IUser } from '@librechat/data-schemas';
 import type { OboTokenResolver, OboTrustChecker } from '~/mcp/oauth/obo';
+import type { MCPElicitationContext } from './connection';
 import type { GraphTokenResolver } from '~/utils/graph';
 import type { FlowStateManager } from '~/flow/manager';
 import type { MCPOAuthTokens } from './oauth';
@@ -28,7 +29,6 @@ import { MCPConnectionFactory } from './MCPConnectionFactory';
 import { preProcessGraphTokens } from '~/utils/graph';
 import { formatToolContent } from './parsers';
 import { MCPConnection } from './connection';
-import type { MCPElicitationContext } from './connection';
 import { processMCPEnv } from '~/utils/env';
 
 function createOboToolCallErrorMessage(

--- a/packages/api/src/mcp/MCPManager.ts
+++ b/packages/api/src/mcp/MCPManager.ts
@@ -28,6 +28,7 @@ import { MCPConnectionFactory } from './MCPConnectionFactory';
 import { preProcessGraphTokens } from '~/utils/graph';
 import { formatToolContent } from './parsers';
 import { MCPConnection } from './connection';
+import type { MCPElicitationContext } from './connection';
 import { processMCPEnv } from '~/utils/env';
 
 function createOboToolCallErrorMessage(
@@ -354,6 +355,7 @@ Please follow these instructions when using tools from the respective MCP server
     flowManager,
     oauthStart,
     oauthEnd,
+    elicitation,
     customUserVars,
     graphTokenResolver,
     oboTokenResolver,
@@ -374,6 +376,8 @@ Please follow these instructions when using tools from the respective MCP server
     flowManager: FlowStateManager<MCPOAuthTokens | null>;
     oauthStart?: t.OAuthStartHandler;
     oauthEnd?: () => Promise<void>;
+    /** Surfaces MCP elicitation prompts to the client and blocks until the user responds. */
+    elicitation?: MCPElicitationContext;
     graphTokenResolver?: GraphTokenResolver;
     oboTokenResolver?: OboTokenResolver;
     oboTrustChecker?: OboTrustChecker;
@@ -512,6 +516,10 @@ Please follow these instructions when using tools from the respective MCP server
 
       connection.setRequestHeaders(resolvedHeaders);
 
+      if (elicitation) {
+        connection.elicitationContext = { ...elicitation, signal: options?.signal };
+      }
+
       const result = await connection.client.request(
         {
           method: 'tools/call',
@@ -539,6 +547,9 @@ Please follow these instructions when using tools from the respective MCP server
       throw error;
     } finally {
       cleanupRequestOAuthHandler?.();
+      if (connection) {
+        connection.elicitationContext = undefined;
+      }
       // Ephemeral connections are never stored in userConnections, so disconnecting
       // is the only cleanup needed; removing the map entry here could orphan a
       // still-connected cached connection from before a config change.

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -5,7 +5,7 @@ import { fetch as undiciFetch, Agent, ProxyAgent } from 'undici';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/websocket.js';
-import { ResourceListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
+import { ElicitRequestSchema, ResourceListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {
   StdioClientTransport,
@@ -18,8 +18,54 @@ import type {
   Dispatcher,
 } from 'undici';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { ElicitRequest, ElicitResult } from '@modelcontextprotocol/sdk/types.js';
 import type { MCPOAuthTokens } from './oauth/types';
 import type * as t from './types';
+
+/** Choice presented to the user in choice-mode elicitation. */
+export type ElicitationChoice = { value: string; label: string };
+
+/**
+ * Per-tool-call context that lets the connection surface an MCP elicitation prompt to the
+ * client and block until the user responds. Set by `MCPManager.callTool` for the duration of
+ * a `tools/call`, then cleared.
+ */
+export interface MCPElicitationContext {
+  flowId: string;
+  signal?: AbortSignal;
+  /** Push the prompt to the chat UI (mirrors the OAuth prompt event). */
+  emit: (payload: {
+    flowId: string;
+    message: string;
+    choices?: ElicitationChoice[];
+    expiresAt?: number;
+  }) => void | Promise<void>;
+  /** Block until the user responds via the elicitation respond endpoint. */
+  resolve: (
+    flowId: string,
+    signal?: AbortSignal,
+  ) => Promise<{ action: 'accept' | 'decline' | 'cancel'; content?: Record<string, unknown> }>;
+}
+
+/** Maps a single-enum requestedSchema into choice buttons; otherwise a plain confirm. */
+function deriveElicitationChoices(
+  requestedSchema: ElicitRequest['params']['requestedSchema'],
+): ElicitationChoice[] | undefined {
+  const properties = requestedSchema?.properties ?? {};
+  const keys = Object.keys(properties);
+  if (keys.length !== 1) {
+    return undefined;
+  }
+  const prop = properties[keys[0]] as {
+    type?: string;
+    enum?: string[];
+    enumNames?: string[];
+  };
+  if (prop?.type !== 'string' || !Array.isArray(prop.enum)) {
+    return undefined;
+  }
+  return prop.enum.map((value, i) => ({ value, label: prop.enumNames?.[i] ?? value }));
+}
 import { createSSRFSafeUndiciConnect, isSSRFTarget, resolveHostnameSSRF } from '~/auth';
 import { runOutsideTracing } from '~/utils/tracing';
 import { isAddressAllowed } from '~/auth/domain';
@@ -1250,12 +1296,50 @@ export class MCPConnection extends EventEmitter {
         version: '1.2.3',
       },
       {
-        capabilities: {},
+        capabilities: { elicitation: {} },
       },
     );
 
     this.setupEventListeners();
+    this.registerElicitationHandler();
   }
+
+  /**
+   * Handles server-initiated `elicitation/create` requests during a tool call: surfaces the
+   * prompt to the chat UI and blocks until the user responds. Without an active per-call
+   * context (no UI to prompt), it declines so the server can proceed safely.
+   */
+  private registerElicitationHandler(): void {
+    this.client.setRequestHandler(ElicitRequestSchema, async (request): Promise<ElicitResult> => {
+      const context = this.elicitationContext;
+      if (!context) {
+        return { action: 'decline' };
+      }
+      if (request.params.mode === 'url') {
+        // URL-mode elicitation is not supported yet.
+        return { action: 'decline' };
+      }
+      const choices = deriveElicitationChoices(request.params.requestedSchema);
+      try {
+        await context.emit({
+          flowId: context.flowId,
+          message: request.params.message,
+          choices,
+          expiresAt: Date.now() + mcpConfig.OAUTH_HANDLING_TIMEOUT,
+        });
+        const result = await context.resolve(context.flowId, context.signal);
+        return result.content != null
+          ? { action: result.action, content: result.content }
+          : { action: result.action };
+      } catch (error) {
+        logger.warn(`${this.getLogPrefix()} Elicitation failed: ${(error as Error).message}`);
+        return { action: 'cancel' };
+      }
+    });
+  }
+
+  /** Per-tool-call elicitation context; set by MCPManager.callTool around a `tools/call`. */
+  public elicitationContext?: MCPElicitationContext;
 
   /** Helper to generate consistent log prefixes */
   private getLogPrefix(): string {

--- a/packages/api/src/mcp/connection.ts
+++ b/packages/api/src/mcp/connection.ts
@@ -5,20 +5,23 @@ import { fetch as undiciFetch, Agent, ProxyAgent } from 'undici';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { WebSocketClientTransport } from '@modelcontextprotocol/sdk/client/websocket.js';
-import { ElicitRequestSchema, ResourceListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {
   StdioClientTransport,
   getDefaultEnvironment,
 } from '@modelcontextprotocol/sdk/client/stdio.js';
+import {
+  ElicitRequestSchema,
+  ResourceListChangedNotificationSchema,
+} from '@modelcontextprotocol/sdk/types.js';
 import type {
   RequestInit as UndiciRequestInit,
   RequestInfo as UndiciRequestInfo,
   Response as UndiciResponse,
   Dispatcher,
 } from 'undici';
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { ElicitRequest, ElicitResult } from '@modelcontextprotocol/sdk/types.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { MCPOAuthTokens } from './oauth/types';
 import type * as t from './types';
 

--- a/packages/api/src/mcp/elicitation/events.ts
+++ b/packages/api/src/mcp/elicitation/events.ts
@@ -1,0 +1,63 @@
+import { GraphEvents, StepTypes } from '@librechat/agents';
+import type * as t from '~/types';
+import type { ElicitationChoice } from '~/mcp/connection';
+
+type ElicitationToolCall = { id?: string; name?: string; type?: string; args?: string };
+
+/**
+ * Run-step delta that surfaces an MCP elicitation prompt on the current tool call. Mirrors the
+ * OAuth prompt delta (`auth`), carrying an `elicitation` payload the client renders as a
+ * confirm/choice prompt and responds to via the elicitation respond endpoint.
+ */
+export function buildMCPElicitationRunStepDeltaEvent({
+  stepId,
+  toolCall,
+  flowId,
+  message,
+  choices,
+  expiresAt,
+}: {
+  stepId: string;
+  toolCall: ElicitationToolCall;
+  flowId: string;
+  message: string;
+  choices?: ElicitationChoice[];
+  expiresAt?: number;
+}): t.ServerSentEvent {
+  return {
+    event: GraphEvents.ON_RUN_STEP_DELTA,
+    data: {
+      id: stepId,
+      delta: {
+        type: StepTypes.TOOL_CALLS,
+        tool_calls: [{ ...toolCall }],
+        elicitation: {
+          flowId,
+          message,
+          ...(choices && choices.length > 0 ? { choices } : {}),
+          ...(expiresAt ? { expires_at: expiresAt } : {}),
+        },
+      },
+    },
+  };
+}
+
+/** Clears the elicitation prompt from the tool call after the user responds. */
+export function buildMCPElicitationEndDeltaEvent({
+  stepId,
+  toolCall,
+}: {
+  stepId: string;
+  toolCall: ElicitationToolCall;
+}): t.ServerSentEvent {
+  return {
+    event: GraphEvents.ON_RUN_STEP_DELTA,
+    data: {
+      id: stepId,
+      delta: {
+        type: StepTypes.TOOL_CALLS,
+        tool_calls: [{ ...toolCall }],
+      },
+    },
+  };
+}

--- a/packages/api/src/mcp/elicitation/events.ts
+++ b/packages/api/src/mcp/elicitation/events.ts
@@ -1,6 +1,6 @@
 import { GraphEvents, StepTypes } from '@librechat/agents';
-import type * as t from '~/types';
 import type { ElicitationChoice } from '~/mcp/connection';
+import type * as t from '~/types';
 
 type ElicitationToolCall = { id?: string; name?: string; type?: string; args?: string };
 

--- a/packages/data-provider/src/api-endpoints.ts
+++ b/packages/data-provider/src/api-endpoints.ts
@@ -220,6 +220,9 @@ export const cancelMCPOAuth = (serverName: string) => {
 
 export const mcpOAuthBind = (serverName: string) => `${BASE_URL}/api/mcp/${serverName}/oauth/bind`;
 
+export const mcpElicitationRespond = (flowId: string) =>
+  `${BASE_URL}/api/mcp/elicitation/${flowId}/respond`;
+
 export const actionOAuthBind = (actionId: string) =>
   `${BASE_URL}/api/actions/${actionId}/oauth/bind`;
 

--- a/packages/data-provider/src/data-service.ts
+++ b/packages/data-provider/src/data-service.ts
@@ -203,6 +203,15 @@ export const bindMCPOAuth = (serverName: string): Promise<{ success: boolean }> 
   return request.post(endpoints.mcpOAuthBind(serverName));
 };
 
+export type MCPElicitationAction = 'accept' | 'decline' | 'cancel';
+
+export const respondMCPElicitation = (
+  flowId: string,
+  body: { action: MCPElicitationAction; content?: Record<string, unknown> },
+): Promise<{ success: boolean }> => {
+  return request.post(endpoints.mcpElicitationRespond(flowId), body);
+};
+
 export const bindActionOAuth = (actionId: string): Promise<{ success: boolean }> => {
   return request.post(endpoints.actionOAuthBind(actionId));
 };

--- a/packages/data-provider/src/types/agents.ts
+++ b/packages/data-provider/src/types/agents.ts
@@ -62,6 +62,27 @@ export namespace Agents {
 
   export type MessageContent = string | MessageContentComplex[];
 
+  /** A single choice presented in a choice-mode elicitation. */
+  export type ElicitationChoice = {
+    value: string;
+    label: string;
+  };
+
+  /**
+   * An MCP elicitation prompt surfaced on a tool call: the server is asking the user to
+   * confirm (or pick an option) before the tool continues.
+   */
+  export type Elicitation = {
+    /** Flow id to respond to via POST /api/mcp/elicitation/:flowId/respond */
+    flowId: string;
+    /** Prompt message to show the user */
+    message: string;
+    /** Optional choices (choice mode); when absent, render a simple confirm/decline */
+    choices?: ElicitationChoice[];
+    /** Expiration time (ms epoch) after which the prompt is stale */
+    expires_at?: number;
+  };
+
   /**
    * A call to a tool.
    */
@@ -83,6 +104,8 @@ export namespace Agents {
     auth?: string;
     /** Expiration time */
     expires_at?: number;
+    /** Pending MCP elicitation prompt (confirm/choice) for this tool call */
+    elicitation?: Elicitation;
   };
 
   export type ToolEndEvent = {
@@ -262,6 +285,7 @@ export namespace Agents {
     tool_calls?: ToolCallChunk[];
     auth?: string;
     expires_at?: number;
+    elicitation?: Elicitation;
   };
   export type AgentToolCall = FunctionToolCall | ToolCall;
   export interface ExtendedMessageContent {


### PR DESCRIPTION
## Summary
Adds **MCP elicitation** so an MCP server can prompt the user mid-tool-call (a confirm/choice dialog) and block until they respond — e.g. BillePrezi's "✅ Confirm this outline" before generating. Mirrors the existing MCP **OAuth** flow (capability → SDK request handler → `FlowStateManager` block → `ON_RUN_STEP_DELTA` event → button in `ToolCall.tsx` → callback endpoint resumes).

## Changes
- **packages/api**: client declares `capabilities.elicitation`; `connection.ts` registers an `ElicitRequest` handler that emits a prompt delta and blocks on a `mcp_elicitation` flow; `MCPManager.callTool` sets a per-call elicitation context; new `mcp/elicitation/events.ts` builders.
- **api/server**: `MCP.js` `_call` builds the emit/resolve wiring and passes `elicitation` into `callTool`; new `POST /api/mcp/elicitation/:flowId/respond` (user-scoped flow id).
- **data-provider**: `Elicitation` type on `ToolCall`/`ToolCallDelta`; `respondMCPElicitation` API.
- **client**: merges the elicitation delta and renders **Confirm/Decline** (and choice) buttons on the tool call, posting the response.

## Scope
- Phase A: **form-mode confirm/choice** only. URL-mode and full JSON-Schema forms are future work.
- Resumable-stream replay of elicitation deltas not yet added (reconnect mid-prompt is a follow-up).

## Requires
- The MCP server must run **stateful** streamable-HTTP to receive server→client requests. Companion: `billeprezibot-mcp` branch `feat/elicitation` (stateful + `create_deck` confirm). Deploy both together.

## Test plan (needs a LibreChat dev/CI env — not verified in authoring sandbox)
- [ ] Build passes (`data-provider`, `api`, `client`).
- [ ] With the stateful billeprezi MCP, call `create_deck` → confirm/decline buttons appear on the tool call.
- [ ] Confirm → deck builds; Decline → "nothing built"; the tool resumes either way.
- [ ] Abort mid-prompt cleans up the flow; non-elicitation clients still work (graceful fallback).

Made with [Cursor](https://cursor.com)